### PR TITLE
Address Build Warnings

### DIFF
--- a/cai_bi/models/dataconsumption/dim_employee.yml
+++ b/cai_bi/models/dataconsumption/dim_employee.yml
@@ -4,7 +4,8 @@ models:
   - name: dim_employee
     tests:
       - dim_employee_row_count_matches_sources:
-          source: ref('employee')
+          arguments:
+            source: ref('employee')
     columns:
       - name: DTS_CREATED_AT
         data_type: TIMESTAMP_LTZ
@@ -16,14 +17,14 @@ models:
         data_type: VARCHAR(250)
       - name: KEY
         data_type: VARCHAR(5000)
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: KEY_BASE_TEAM
         data_type: VARCHAR(5000)
       - name: KEY_COMPANY
         data_type: NUMBER(38,0)
-        tests:
+        data_tests:
           - not_null:
               severity: warn
           - unique:
@@ -42,7 +43,7 @@ models:
         data_type: NUMBER(38,0)
       - name: KEY_ENTITY
         data_type: NUMBER(38,0)
-        tests:
+        data_tests:
           - not_null:
               severity: warn
           - unique:
@@ -211,7 +212,7 @@ models:
         data_type: VARCHAR(5000)
       - name: CURRENCY_CODE
         data_type: VARCHAR(5000)
-      - name: DIETERY_NEEDS
+      - name: DIETARY_NEEDS
         data_type: VARCHAR(5000)
       - name: DISPLAY_NAME
         data_type: VARCHAR(5000)
@@ -255,7 +256,7 @@ models:
         data_type: VARCHAR(5000)
       - name: JOB_SALARY_GRADE
         data_type: NUMBER(38,17)
-        name: JOB_SALARY_GRADE_NAME
+      - name: JOB_SALARY_GRADE_NAME
         data_type: VARCHAR(5000)
       - name: JOB_TITLE
         data_type: VARCHAR(5000)


### PR DESCRIPTION
Attempts to clean up the warnings cropping up in [dbt production builds](https://github.com/DataVoke/snowflakeBI/actions/runs/18167454161/job/51713331414#step:7:15).

* Adds missing delimiter to mitigate duplicate key warnings per #234 
* Nests test arguments in the `arguments` property
* Fixed spelling of `DIETERY_NEEDS` -> `DIETARY_NEEDS` to match SQL statement and production tables (unsure what the implications are elsewhere)
* Renamed `tests` to `data_tests` for unit tests: https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax

On the last item: we may not need a ticket for it to fix existing tests, but the linked docs go into detail about how this is tied to the implementation of unit tests. The `tests` alias still works in this context but I included and tested what the change would look like here. 